### PR TITLE
Check if the url used already contains params

### DIFF
--- a/lib/jira/jwt_client.rb
+++ b/lib/jira/jwt_client.rb
@@ -2,6 +2,8 @@ require 'atlassian/jwt'
 
 module JIRA
   class JwtClient < HttpClient
+    DEFAULT_OPTIONS = { shared_secret: 'shared_secret_key' }.freeze
+
     def make_request(http_method, url, body = '', headers = {})
       @http_method = http_method
 
@@ -14,24 +16,52 @@ module JIRA
       super(url, data, headers)
     end
 
+    class JwtUriBuilder
+      attr_reader :request_url, :http_method, :shared_secret, :site, :issuer
+
+      def initialize(request_url, http_method, shared_secret, site, issuer)
+        @request_url = request_url
+        @http_method = http_method
+        @shared_secret = shared_secret
+        @site = site
+        @issuer = issuer
+      end
+
+      def build
+        uri = URI.parse(request_url)
+        new_query = URI.decode_www_form(String(uri.query)) << ['jwt', jwt_header]
+        uri.query = URI.encode_www_form(new_query)
+
+        return uri.to_s unless uri.is_a?(URI::HTTP)
+
+        uri.request_uri
+      end
+
+      def jwt_header
+        claim = Atlassian::Jwt.build_claims \
+          issuer,
+          request_url,
+          http_method.to_s,
+          site,
+          (Time.now - 60).to_i,
+          (Time.now + 86_400).to_i
+
+        JWT.encode claim, shared_secret
+      end
+    end
+
     private
 
     attr_accessor :http_method
 
     def request_path(url)
-      super(url) + "?jwt=#{jwt_header(url)}"
-    end
-
-    def jwt_header(url)
-      claim = Atlassian::Jwt.build_claims \
-        @options[:issuer],
+      JwtUriBuilder.new(
         url,
-        http_method.to_s,
+        http_method,
+        @options[:shared_secret],
         @options[:site],
-        (Time.now - 60).to_i,
-        (Time.now + (86400)).to_i
-
-      JWT.encode claim, @options[:shared_secret]
+        @options[:issuer]
+      ).build
     end
   end
 end

--- a/lib/jira/jwt_client.rb
+++ b/lib/jira/jwt_client.rb
@@ -37,6 +37,8 @@ module JIRA
         uri.request_uri
       end
 
+      private
+
       def jwt_header
         claim = Atlassian::Jwt.build_claims \
           issuer,

--- a/spec/jira/jwt_uri_builder_spec.rb
+++ b/spec/jira/jwt_uri_builder_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe JIRA::JwtClient::JwtUriBuilder do
+  subject(:url_builder) do
+    JIRA::JwtClient::JwtUriBuilder.new(url, http_method, shared_secret, site, issuer)
+  end
+
+  let(:url) { '/foo' }
+  let(:http_method) { :get }
+  let(:shared_secret) { 'shared_secret' }
+  let(:site) { 'http://localhost:2990' }
+  let(:issuer) { nil }
+
+  describe '#build' do
+    subject { url_builder.build }
+
+    it 'includes the jwt param' do
+      expect(subject).to include('?jwt=')
+    end
+
+    context 'when the url already contains params' do
+      let(:url) { '/foo?expand=projects.issuetypes.fields' }
+
+      it 'includes the jwt param' do
+        expect(subject).to include('&jwt=')
+      end
+    end
+
+    context 'with a complete url' do
+      let(:url) { 'http://localhost:2990/rest/api/2/issue/createmeta' }
+
+      it 'includes the jwt param' do
+        expect(subject).to include('?jwt=')
+      end
+
+      it { is_expected.to start_with('/') }
+
+      it 'contains only one ?' do
+        expect(subject.count('?')).to eq(1)
+      end
+    end
+
+    context 'with a complete url containing a param' do
+      let(:url) do
+        'http://localhost:2990/rest/api/2/issue/createmeta?expand=projects.issuetypes.fields'
+      end
+
+      it 'includes the jwt param' do
+        expect(subject).to include('&jwt=')
+      end
+
+      it { is_expected.to start_with('/') }
+
+      it 'contains only one ?' do
+        expect(subject.count('?')).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the url passed to `make_request` already contains a param it would add the jwt param incorrectly. This makes sure that doesn't happen again.